### PR TITLE
Split deduplication email once

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-55/0-55-deduplicate-indexed-fields.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-55/0-55-deduplicate-indexed-fields.command.ts
@@ -148,9 +148,11 @@ export class DeduplicateIndexedFieldsCommand extends ActiveOrSuspendedWorkspaces
         order: { createdAt: 'DESC' },
       });
 
+      const emailParts = person_emailsPrimaryEmail.split('@');
+
       for (let i = 1; i < persons.length; i++) {
         const newEmail = person_emailsPrimaryEmail?.includes('@')
-          ? `${person_emailsPrimaryEmail.split('@')[0]}+${i}@${person_emailsPrimaryEmail.split('@')[1]}`
+          ? `${emailParts[0]}+${i}@${emailParts[1]}`
           : `${person_emailsPrimaryEmail}+${i}`;
 
         if (!dryRun) {


### PR DESCRIPTION
## Summary
- split the primary email once before looping when deduplicating indexed fields

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*
- `yarn test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_687e4ac0af5c8328aadbf447e012a850